### PR TITLE
make mouse buttons optional

### DIFF
--- a/Dialog/English.txt
+++ b/Dialog/English.txt
@@ -7,7 +7,11 @@ PORTALINE_SETTINGS_OVERRIDE=
 PORTALINE_SETTINGS_OVERRIDE_HINT=
   By default, the portal gun is disabled upon entering a level.
   If you set this to ON, the portal gun will always be enabled.
-  -----
-  Note: In addition to the keyboard and joystick settings below,
+
+PORTALINE_SETTINGS_MOUSE_BUTTONS=
+  Use Mouse Buttons
+
+PORTALINE_SETTINGS_MOUSE_BUTTONS_HINT=
+  If enabled, in addition to the keyboard and joystick settings below,
   you can also shoot blue portals with the left mouse button,
   and orange portals with the right mouse button.

--- a/Source/PortalineModule.cs
+++ b/Source/PortalineModule.cs
@@ -231,13 +231,13 @@ public class PortalineModule : EverestModule {
     // PortalBullet..ctor() adds itself to the scene on creation
     // so the result is not unused
 #pragma warning disable CA1806 // Do not ignore method results
-    if (Settings.ShootBluePortal.Pressed || MInput.Mouse.PressedLeftButton) {
+    if (Settings.ShootBluePortal.Pressed || (Settings.PortalUseMouseButtons && MInput.Mouse.PressedLeftButton)) {
       self.Facing = (Facings)Math.Sign(ToCursor(self, CursorPos).X);
       if (self.Facing == 0) self.Facing = Facings.Right;
       Audio.Play("event:/sneezingcactus/portal_shoot_blue");
       new PortalBullet(self.Center, ToCursor(self, CursorPos) * 15f, false, self);
     }
-    if (Settings.ShootOrangePortal.Pressed || MInput.Mouse.PressedRightButton) {
+    if (Settings.ShootOrangePortal.Pressed || (Settings.PortalUseMouseButtons && MInput.Mouse.PressedRightButton)) {
       self.Facing = (Facings)Math.Sign(ToCursor(self, CursorPos).X);
       if (self.Facing == 0) self.Facing = Facings.Right;
       Audio.Play("event:/sneezingcactus/portal_shoot_orange");

--- a/Source/PortalineModuleSettings.cs
+++ b/Source/PortalineModuleSettings.cs
@@ -8,6 +8,10 @@ public class PortalineModuleSettings : EverestModuleSettings {
   [SettingSubText("PORTALINE_SETTINGS_OVERRIDE_HINT")]
   public bool PortalGunOverrideEnable { get; set; } = false;
 
+  [SettingName("PORTALINE_SETTINGS_MOUSE_BUTTONS")]
+  [SettingSubText("PORTALINE_SETTINGS_MOUSE_BUTTONS_HINT")]
+  public bool PortalUseMouseButtons { get; set; } = true;
+
   [DefaultButtonBinding(Buttons.LeftShoulder, Keys.O)]
   public ButtonBinding ShootBluePortal { get; set; }
 


### PR DESCRIPTION
add the option to disable using the mouse buttons to shoot, in case you would rather use those buttons for something else (as is the case for me)